### PR TITLE
Allow the developer to specify a path to the node executable. Fixes #6.

### DIFF
--- a/config/react-email.php
+++ b/config/react-email.php
@@ -1,5 +1,7 @@
 <?php
 
 return [
-    'template_directory' => env('REACT_EMAIL_DIRECTORY')
+    'template_directory' => env('REACT_EMAIL_DIRECTORY'),
+
+    'node_path' => env('REACT_EMAIL_NODE_PATH'),
 ];

--- a/src/Exceptions/NodeNotFoundException.php
+++ b/src/Exceptions/NodeNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Maantje\ReactEmail\Exceptions;
+
+use Exception;
+
+class NodeNotFoundException extends Exception
+{
+    //
+}

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -53,7 +53,7 @@ class Renderer extends Process
      */
     public static function resolveNodeExecutable(): string
     {
-        if ($executable = config('react-emails.node_path', app(ExecutableFinder::class)->find('node')))
+        if ($executable = config('react-email.node_path', app(ExecutableFinder::class)->find('node')))
         {
             return $executable;
         }

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -53,7 +53,7 @@ class Renderer extends Process
      */
     public static function resolveNodeExecutable(): string
     {
-        if ($executable = config('react-email.node_path', app(ExecutableFinder::class)->find('node')))
+        if ($executable = config('react-email.node_path') ?? app(ExecutableFinder::class)->find('node'))
         {
             return $executable;
         }

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -2,7 +2,6 @@
 
 namespace Maantje\ReactEmail;
 
-use Exception;
 use Maantje\ReactEmail\Exceptions\NodeNotFoundException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
@@ -13,7 +12,7 @@ class Renderer extends Process
     /**
      * @param string $view
      * @param array $data
-     * @throws Exception
+     * @throws NodeNotFoundException
      */
     private function __construct(string $view, array $data = [])
     {
@@ -50,7 +49,7 @@ class Renderer extends Process
      * Resolve the node path from the configuration or executable finder.
      *
      * @return string
-     * @throws Exception
+     * @throws NodeNotFoundException
      */
     public static function resolveNodeExecutable(): string
     {

--- a/tests/Unit/MailableTest.php
+++ b/tests/Unit/MailableTest.php
@@ -4,12 +4,29 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use Maantje\ReactEmail\Exceptions\NodeNotFoundException;
 use Maantje\ReactEmail\ReactMailable;
+use Maantje\ReactEmail\Renderer;
+use Mockery\MockInterface;
+use Symfony\Component\Process\ExecutableFinder;
 
 it('renders the html and text from react-email', function () {
     (new TestMailable)
         ->assertSeeInHtml(EXPECTED_HTML, false)
         ->assertSeeInText('Hello from react email, test');
+});
+
+it('throws an exception if node executable is not resolved', function () {
+    $this->expectException(NodeNotFoundException::class);
+
+    $this->instance(
+        ExecutableFinder::class,
+        Mockery::mock(ExecutableFinder::class, function (MockInterface $mock) {
+            $mock->shouldReceive('find')->andReturn(null);
+        })
+    );
+
+    (new TestMailable)->render();
 });
 
 const EXPECTED_HTML = <<<HTML

--- a/tests/Unit/MailableTest.php
+++ b/tests/Unit/MailableTest.php
@@ -17,6 +17,8 @@ it('renders the html and text from react-email', function () {
 });
 
 it('throws an exception if node executable is not resolved', function () {
+    config()->set('react-email.node_path');
+
     $this->expectException(NodeNotFoundException::class);
 
     $this->instance(
@@ -27,6 +29,12 @@ it('throws an exception if node executable is not resolved', function () {
     );
 
     (new TestMailable)->render();
+});
+
+it('prioritises configuration value over executable finder', function () {
+    config()->set('react-email.node_path', '/path/to/node');
+
+    expect(Renderer::resolveNodeExecutable())->toEqual('/path/to/node');
 });
 
 const EXPECTED_HTML = <<<HTML


### PR DESCRIPTION
I was facing an issue where the `ExecutableFinder` could not resolve the path to my homebrew node installation. 

Performing `which node` revealed that I was using homebrew. Hardcoding this string into the package allowed the executable to run and the email to be sent.

